### PR TITLE
build: Refactor Dockerfile to utilize official images for most Go too…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,26 +2,19 @@
 # Installs all 15 security tools for comprehensive penetration testing
 
 # ============================================================================
-# Stage 1: Builder - Install Go tools and build dependencies
+# Tool Stages: Pull official binaries or build from source
 # ============================================================================
-FROM golang:1.22-alpine AS builder
+# Build ffuf from source (official image not available/public)
+FROM golang:alpine AS builder
+RUN go install -v github.com/ffuf/ffuf/v2@latest
 
-WORKDIR /build
-
-# Install build dependencies
-RUN apk add --no-cache \
-    git \
-    gcc \
-    musl-dev
-
-# Install Go-based security tools
-RUN go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest && \
-    go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest && \
-    go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest && \
-    go install -v github.com/OJ/gobuster/v3@latest && \
-    go install -v github.com/ffuf/ffuf/v2@latest && \
-    go install -v github.com/owasp-amass/amass/v4/...@master && \
-    go install -v github.com/zricethezav/gitleaks/v8@latest
+# Pull official binaries for other tools
+FROM projectdiscovery/httpx:latest AS httpx
+FROM projectdiscovery/subfinder:latest AS subfinder
+FROM projectdiscovery/nuclei:latest AS nuclei
+FROM ghcr.io/oj/gobuster:latest AS gobuster
+FROM owaspamass/amass:latest AS amass
+FROM zricethezav/gitleaks:latest AS gitleaks
 
 # ============================================================================
 # Stage 2: Runtime - Python environment with all tools
@@ -42,6 +35,7 @@ ENV PYTHONUNBUFFERED=1 \
 WORKDIR ${GUARDIAN_HOME}
 
 # Install system dependencies and security tools
+# Added gcompat for Go binary compatibility
 RUN apk add --no-cache \
     # Build dependencies
     gcc \
@@ -53,6 +47,7 @@ RUN apk add --no-cache \
     nmap-scripts \
     git \
     curl \
+    gcompat \
     # Ruby for WhatWeb and WPScan
     ruby \
     ruby-dev \
@@ -80,10 +75,14 @@ RUN apk add --no-cache \
     # Clean up build dependencies
     apk del make gcc musl-dev
 
-
-
-# Copy Go tools from builder
-COPY --from=builder /go/bin/* /usr/local/bin/
+# Copy Go tools from official images
+COPY --from=httpx /usr/local/bin/httpx /usr/local/bin/
+COPY --from=subfinder /usr/local/bin/subfinder /usr/local/bin/
+COPY --from=nuclei /usr/local/bin/nuclei /usr/local/bin/
+COPY --from=gobuster /app/gobuster /usr/local/bin/gobuster
+COPY --from=builder /go/bin/ffuf /usr/local/bin/
+COPY --from=amass /bin/amass /usr/local/bin/
+COPY --from=gitleaks /usr/bin/gitleaks /usr/local/bin/
 
 # Install Python-based security tools
 RUN pip install --no-cache-dir \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,110 @@
+# Makefile for Guardian CLI
+# Automation of common development and deployment tasks
+
+# -----------------------------------------------------------------------------
+# Variables
+# -----------------------------------------------------------------------------
+VENV := .venv
+PYTHON := $(VENV)/bin/python
+PIP := $(PYTHON) -m pip
+DOCKER := docker
+DOCKER_COMPOSE := docker-compose
+APP_NAME := guardian-cli
+IMAGE_NAME := guardian-cli
+VERSION := $(shell grep "version =" pyproject.toml | head -n 1 | cut -d '"' -f 2)
+
+# Colors for help message
+CYAN := \033[36m
+RESET := \033[0m
+
+# -----------------------------------------------------------------------------
+# Default target
+# -----------------------------------------------------------------------------
+.DEFAULT_GOAL := help
+
+# -----------------------------------------------------------------------------
+# Help
+# -----------------------------------------------------------------------------
+.PHONY: help
+help: ## Display this help message
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-20s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+# -----------------------------------------------------------------------------
+# Development
+# -----------------------------------------------------------------------------
+.PHONY: venv
+venv: ## Create virtual environment
+	test -d $(VENV) || python3 -m venv $(VENV)
+
+.PHONY: setup
+setup: venv ## Initialize development environment (.env, venv, directories)
+	test -f .env || cp .env.example .env
+	mkdir -p reports logs
+	# @echo " Environment initialized. Please edit .env with your API keys."
+
+.PHONY: install
+# -----------------------------------------------------------------------------
+.PHONY: install
+install: venv ## Install dependencies for development
+	$(PIP) install -e ".[dev]"
+
+.PHONY: update
+update: ## Update dependencies
+	$(PIP) install --upgrade -e ".[dev]"
+
+.PHONY: clean
+clean: ## Clean up build artifacts and cache
+	rm -rf build/ dist/ *.egg-info .pytest_cache .ruff_cache
+	find . -type d -name "__pycache__" -exec rm -rf {} +
+	find . -type f -name "*.pyc" -delete
+
+# -----------------------------------------------------------------------------
+# Quality Assurance
+# -----------------------------------------------------------------------------
+.PHONY: lint
+lint: ## Run linting (ruff & black check)
+	ruff check .
+	black --check .
+
+.PHONY: format
+format: ## Format code (black & ruff fix)
+	black .
+	ruff check --fix .
+
+.PHONY: test
+test: ## Run tests
+	pytest
+
+# -----------------------------------------------------------------------------
+# Docker
+# -----------------------------------------------------------------------------
+.PHONY: docker-build
+docker-build: ## Build the Docker image
+	$(DOCKER) build -t $(IMAGE_NAME):latest -t $(IMAGE_NAME):$(VERSION) .
+
+.PHONY: docker-run
+docker-run: ## Run the Docker container
+	$(DOCKER) run --rm -it $(IMAGE_NAME):latest
+
+.PHONY: compose-up
+compose-up: ## Start services with Docker Compose
+	$(DOCKER_COMPOSE) up -d
+
+.PHONY: compose-down
+compose-down: ## Stop services with Docker Compose
+	$(DOCKER_COMPOSE) down
+
+.PHONY: compose-logs
+compose-logs: ## View logs from Docker Compose services
+	$(DOCKER_COMPOSE) logs -f
+
+# -----------------------------------------------------------------------------
+# CLI Execution
+# -----------------------------------------------------------------------------
+.PHONY: run
+run: ## Run the CLI tool (usage: make run ARGS="scan --target example.com")
+	$(PYTHON) -m cli.main $(ARGS)
+


### PR DESCRIPTION
This pull request introduces significant improvements to the Docker build process for the Guardian CLI and adds a new `Makefile` to streamline development and deployment tasks. The Dockerfile is refactored to use official binaries for most Go-based security tools, improving reliability and reducing build complexity. Additionally, a `Makefile` is introduced to automate common workflows such as environment setup, dependency management, linting, testing, and Docker operations.

**Dockerfile refactor and improvements:**

* Refactored the Dockerfile to use official binaries for most Go-based security tools (such as `httpx`, `subfinder`, `nuclei`, `gobuster`, `amass`, `gitleaks`), and to build only `ffuf` from source, simplifying the build process and improving reliability. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L5-R17) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L83-R85)
* Added `gcompat` to the list of installed packages to ensure compatibility with Go binaries in the Alpine-based image. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R38) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R50)

**Development workflow enhancements:**

* Added a comprehensive `Makefile` to automate environment setup, dependency installation, code formatting, linting, testing, Docker build/run, and CLI execution, making development and deployment more efficient and standardized.