### PR TITLE
Feat/add litellm provider

### DIFF
--- a/ai/providers/__init__.py
+++ b/ai/providers/__init__.py
@@ -6,7 +6,6 @@ Provider factory and registry for different AI providers
 from typing import Dict, Any, Optional
 from utils.logger import get_logger
 
-
 # In-tree provider registry. Maps name → "module.path.ClassName".
 # Third parties extend this WITHOUT editing the dict by declaring an
 # entry-point in their own pyproject.toml:
@@ -26,6 +25,7 @@ PROVIDERS: Dict[str, str] = {
     # New in v4: shipped in-tree but follow the plugin contract.
     "ollama": "ai.providers.ollama_provider.OllamaProvider",
     "openai_compatible": "ai.providers.openai_compatible_provider.OpenAICompatibleProvider",
+    "litellm": "ai.providers.litellm_provider.LiteLLMProvider",
 }
 
 _ENTRY_POINT_GROUP = "guardian.providers"
@@ -96,16 +96,14 @@ def get_provider(config: Dict[str, Any]):
 
     if provider_name not in registry:
         available = ", ".join(sorted(registry.keys()))
-        raise ValueError(
-            f"Unknown provider: {provider_name}. "
-            f"Available providers: {available}"
-        )
+        raise ValueError(f"Unknown provider: {provider_name}. " f"Available providers: {available}")
 
     provider_path = registry[provider_name]
     module_path, class_name = provider_path.rsplit(".", 1)
 
     try:
         import importlib
+
         module = importlib.import_module(module_path)
         provider_class = getattr(module, class_name)
         provider = provider_class(config, logger)

--- a/ai/providers/litellm_provider.py
+++ b/ai/providers/litellm_provider.py
@@ -124,6 +124,8 @@ class LiteLLMProvider(BaseProvider):
             return await litellm.acompletion(messages=messages, **self._base_kwargs())
 
         response = await self._with_retry(_call, self._is_retriable)
+        if not response.choices:
+            raise ValueError("LiteLLM returned empty choices list")
         return str(response.choices[0].message.content or "")
 
     def generate_sync(
@@ -136,8 +138,23 @@ class LiteLLMProvider(BaseProvider):
         import litellm
 
         messages = self._build_messages(prompt, system_prompt, context)
-        response = litellm.completion(messages=messages, **self._base_kwargs())
-        return str(response.choices[0].message.content or "")
+        kwargs = self._base_kwargs()
+
+        last_err = None
+        for attempt in range(max(getattr(self, "_retry_attempts", 2), 1)):
+            try:
+                response = litellm.completion(messages=messages, **kwargs)
+                if not response.choices:
+                    raise ValueError("LiteLLM returned empty choices list")
+                return str(response.choices[0].message.content or "")
+            except Exception as e:
+                last_err = e
+                if not self._is_retriable(e) or attempt >= self._retry_attempts - 1:
+                    raise
+                import time
+
+                time.sleep(min(2**attempt, 30))
+        raise last_err
 
     async def generate_with_usage(
         self,
@@ -154,6 +171,8 @@ class LiteLLMProvider(BaseProvider):
             return await litellm.acompletion(messages=messages, **self._base_kwargs())
 
         response = await self._with_retry(_call, self._is_retriable)
+        if not response.choices:
+            raise ValueError("LiteLLM returned empty choices list")
 
         usage = getattr(response, "usage", None) or {}
         prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
@@ -188,6 +207,7 @@ class LiteLLMProvider(BaseProvider):
             "litellm.exceptions.Timeout",
             "litellm.exceptions.InternalServerError",
             "litellm.exceptions.ServiceUnavailableError",
+            "litellm.exceptions.BadGatewayError",
         }:
             return True
         return BaseProvider.default_is_retriable(exc)

--- a/ai/providers/litellm_provider.py
+++ b/ai/providers/litellm_provider.py
@@ -1,0 +1,193 @@
+"""
+LiteLLM Provider Implementation
+Access 100+ LLM providers (OpenAI, Anthropic, Google, Azure, Bedrock,
+Cohere, Mistral, …) through a single unified interface.
+
+Users specify the model with provider-prefixed names, e.g.:
+  anthropic/claude-sonnet-4-6
+  openai/gpt-4o
+  gemini/gemini-2.5-pro
+  bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0
+
+Config block in ``guardian.yaml``:
+
+    ai:
+      provider: litellm
+      litellm:
+        model: anthropic/claude-sonnet-4-6
+        api_key: null         # Or set provider-specific env vars
+        api_base: null        # Optional: proxy URL
+        drop_params: true     # Drop unsupported params per provider
+
+Install:  pip install guardian-cli[litellm]
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+from ai.providers.base_provider import BaseProvider
+
+
+def _check_litellm():
+    try:
+        import litellm  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+class LiteLLMProvider(BaseProvider):
+    """LiteLLM AI gateway provider — 100+ LLM providers via one interface."""
+
+    def __init__(self, config: Dict[str, Any], logger):
+        super().__init__(config, logger)
+
+        ai_config = config.get("ai", {})
+        litellm_config = ai_config.get("litellm", {})
+
+        self.model_name = litellm_config.get("model") or ai_config.get("model", "openai/gpt-4o")
+        self.api_key = litellm_config.get("api_key") or os.environ.get("LITELLM_API_KEY")
+        self.api_base = litellm_config.get("api_base") or os.environ.get("LITELLM_API_BASE")
+        self.drop_params = litellm_config.get("drop_params", True)
+        self.temperature = ai_config.get("temperature", 0.2)
+        self.max_tokens = ai_config.get("max_tokens", 8000)
+
+        self._available = False
+        self._initialize()
+
+    def _initialize(self):
+        if not _check_litellm():
+            raise RuntimeError(
+                "litellm not installed. Install with: pip install guardian-cli[litellm]"
+            )
+        self._available = True
+        self.logger.info(f"Initialized LiteLLM provider: {self.model_name}")
+
+    def _build_messages(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        context: Optional[list] = None,
+    ) -> List[Dict[str, str]]:
+        messages: List[Dict[str, str]] = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        if context:
+            for msg in context:
+                if isinstance(msg, dict):
+                    messages.append(
+                        {
+                            "role": msg.get("role", "user"),
+                            "content": msg.get("content", ""),
+                        }
+                    )
+                elif hasattr(msg, "content"):
+                    role = getattr(msg, "type", "human")
+                    if role in ("human", "HumanMessage"):
+                        role = "user"
+                    elif role in ("ai", "AIMessage"):
+                        role = "assistant"
+                    elif role in ("system", "SystemMessage"):
+                        role = "system"
+                    messages.append({"role": role, "content": msg.content})
+        messages.append({"role": "user", "content": prompt})
+        return messages
+
+    def _base_kwargs(self) -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {
+            "model": self.model_name,
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+            "drop_params": self.drop_params,
+        }
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.api_base:
+            kwargs["api_base"] = self.api_base
+        return kwargs
+
+    async def generate(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        context: Optional[list] = None,
+    ) -> str:
+        await self._apply_rate_limit()
+        import litellm
+
+        messages = self._build_messages(prompt, system_prompt, context)
+
+        async def _call():
+            return await litellm.acompletion(messages=messages, **self._base_kwargs())
+
+        response = await self._with_retry(_call, self._is_retriable)
+        return str(response.choices[0].message.content or "")
+
+    def generate_sync(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        context: Optional[list] = None,
+    ) -> str:
+        self._apply_rate_limit_sync()
+        import litellm
+
+        messages = self._build_messages(prompt, system_prompt, context)
+        response = litellm.completion(messages=messages, **self._base_kwargs())
+        return str(response.choices[0].message.content or "")
+
+    async def generate_with_usage(
+        self,
+        prompt: str,
+        system_prompt: str,
+        context: Optional[list] = None,
+    ) -> Dict[str, Any]:
+        await self._apply_rate_limit()
+        import litellm
+
+        messages = self._build_messages(prompt, system_prompt, context)
+
+        async def _call():
+            return await litellm.acompletion(messages=messages, **self._base_kwargs())
+
+        response = await self._with_retry(_call, self._is_retriable)
+
+        usage = getattr(response, "usage", None) or {}
+        prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
+        completion_tokens = getattr(usage, "completion_tokens", 0) or 0
+        total_tokens = getattr(usage, "total_tokens", 0) or (prompt_tokens + completion_tokens)
+
+        self._enforce_token_budget(total_tokens)
+
+        return {
+            "response": str(response.choices[0].message.content or ""),
+            "reasoning": "",
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+            "cost_usd": self._estimate_cost(prompt_tokens, completion_tokens),
+            "model": self.model_name,
+            "provider": "litellm",
+        }
+
+    def get_model_name(self) -> str:
+        return self.model_name
+
+    def is_available(self) -> bool:
+        return self._available
+
+    @staticmethod
+    def _is_retriable(exc: BaseException) -> bool:
+        qualname = f"{type(exc).__module__}.{type(exc).__name__}"
+        if qualname in {
+            "litellm.exceptions.RateLimitError",
+            "litellm.exceptions.APIConnectionError",
+            "litellm.exceptions.Timeout",
+            "litellm.exceptions.InternalServerError",
+            "litellm.exceptions.ServiceUnavailableError",
+        }:
+            return True
+        return BaseProvider.default_is_retriable(exc)

--- a/config/guardian.yaml
+++ b/config/guardian.yaml
@@ -3,7 +3,7 @@
 
 # AI Configuration
 ai:
-  # Active Provider: gemini, openai, claude, openrouter, requesty
+  # Active Provider: gemini, openai, claude, openrouter, requesty, litellm
   provider: openai
   
   # Gemini Configuration
@@ -30,6 +30,13 @@ ai:
   requesty:
     model: openai/gpt-4o-mini
     api_key: null  # Or set REQUESTY_API_KEY environment variable
+
+  # LiteLLM Configuration (100+ providers via unified interface)
+  litellm:
+    model: openai/gpt-4o  # Provider-prefixed model name
+    api_key: null  # Or set provider-specific env vars (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)
+    api_base: null  # Optional: LiteLLM proxy URL
+    drop_params: true  # Silently drop unsupported params per provider
   
   # General AI Settings (applied to all providers)
   temperature: 0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ dev = [
     "black>=23.12.0",
     "ruff>=0.1.0",
 ]
+litellm = [
+    "litellm>=1.80,<1.87",
+]
 
 [project.scripts]
 guardian = "cli.main:app"


### PR DESCRIPTION
## Summary

- Add LiteLLM as a new AI gateway provider, giving Guardian users access to 100+ LLM providers (OpenAI, Anthropic, Google, Azure, Bedrock, Cohere, Mistral, and more) through a single unified interface.
- Follows the existing `BaseProvider` pattern with lazy import so `litellm` stays an optional dependency.

## Motivation

Guardian currently supports 7 individual providers, each requiring separate configuration. Users who want to use providers not yet supported (Azure Bedrock, Mistral, Cohere, Together AI, etc.) have no path beyond `openai_compatible` with a manually configured proxy.

LiteLLM solves this by routing to 100+ providers through provider-prefixed model names (e.g., `anthropic/claude-sonnet-4-6`, `bedrock/anthropic.claude-3-5-sonnet`). Users switch providers by changing one config line - no proxy server needed.

## Prior art

- No existing LiteLLM PRs or issues in this repo.
- `zakirkun/deep-eye` (same author) already has a merged LiteLLM integration ([deep-eye#37](https://github.com/zakirkun/deep-eye/pull/37)).

## Changes

- `ai/providers/litellm_provider.py` - new `LiteLLMProvider` implementing `BaseProvider`
- `ai/providers/__init__.py` - registered `"litellm"` in the `PROVIDERS` dict
- `pyproject.toml` - added `litellm>=1.80,<1.87` as optional dependency (`pip install guardian-cli[litellm]`)
- `config/guardian.yaml` - added `litellm` config block and listed in active provider comment

## Tests

**1. Live E2E against Anthropic (via Azure Foundry):**

```
$ ANTHROPIC_API_KEY=<key> ANTHROPIC_API_BASE=<url> python3 test_litellm.py

INFO:test:Initialized LiteLLM provider: anthropic/claude-sonnet-4-6
LiteLLM completion() model= claude-sonnet-4-6; provider = anthropic
Response: 4
Tokens: prompt=31, completion=5, total=36
Model: anthropic/claude-sonnet-4-6
Provider: litellm
```

Full chain verified: `LiteLLMProvider.generate_with_usage()` -> `litellm.acompletion()` -> Anthropic API -> response parsed with token tracking.

**2. Lint clean:**

```
$ black --check --line-length 100 ai/providers/litellm_provider.py ai/providers/__init__.py
All done! 2 files would be left unchanged.

$ ruff check ai/providers/litellm_provider.py ai/providers/__init__.py
All checks passed!
```

## Implementation details

- Uses `litellm.acompletion()` / `litellm.completion()` directly (not through LangChain) for maximum provider coverage without extra wrapper deps.
- `drop_params=True` by default - silently drops provider-unsupported kwargs (e.g., `seed` on Anthropic, `strict` on Gemini).
- Retry uses qualname-based `_is_retriable()` that recognizes LiteLLM's exception types (`RateLimitError`, `APIConnectionError`, `Timeout`, etc.) without importing them at module level.
- Lazy `import litellm` inside function bodies so users who don't install the optional extra aren't broken.
- Handles both dict-style and LangChain message objects in `_build_messages()` for full compatibility with Guardian's agent pipeline.

## Risk / Compatibility

- Additive only. Existing providers untouched.
- `litellm` is an optional extra - base install unaffected.
- Provider resolves via the existing factory pattern (`get_provider()` with lazy `importlib`).

## Example usage

**Config:**
```yaml
# config/guardian.yaml
ai:
  provider: litellm
  litellm:
    model: anthropic/claude-sonnet-4-6
```

**CLI:**
```bash
# Set provider-specific env var (LiteLLM reads these automatically)
export ANTHROPIC_API_KEY=sk-ant-...

# Run a workflow
guardian workflow run --name web_pentest --target https://example.com --provider litellm
```

**Python:**
```python
from ai.providers import get_provider

config = {
    "ai": {
        "provider": "litellm",
        "litellm": {
            "model": "anthropic/claude-sonnet-4-6",  # or openai/gpt-4o, gemini/gemini-2.5-pro, etc.
            "drop_params": True,
        },
        "temperature": 0.2,
        "max_tokens": 8000,
    }
}
provider = get_provider(config)
response = await provider.generate_with_usage(
    prompt="Analyze this target for vulnerabilities",
    system_prompt="You are a security analyst.",
)
print(response["response"])
print(f"Tokens: {response['prompt_tokens']}+{response['completion_tokens']}")
```
